### PR TITLE
Add Prometheus Remote Write (PRW) Exporter to Collector  Lambda Layer

### DIFF
--- a/collector/lambdacomponents/default.go
+++ b/collector/lambdacomponents/default.go
@@ -20,6 +20,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/loggingexporter"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
 	"go.opentelemetry.io/collector/exporter/otlphttpexporter"
+	"go.opentelemetry.io/collector/exporter/prometheusremotewriteexporter"
 	"go.opentelemetry.io/collector/processor/attributesprocessor"
 	"go.opentelemetry.io/collector/processor/filterprocessor"
 	"go.opentelemetry.io/collector/processor/memorylimiter"
@@ -43,6 +44,7 @@ func Components() (component.Factories, error) {
 		loggingexporter.NewFactory(),
 		otlpexporter.NewFactory(),
 		otlphttpexporter.NewFactory(),
+		prometheusremotewriteexporter.NewFactory(),
 	)
 	if err != nil {
 		errs = append(errs, err)
@@ -61,8 +63,8 @@ func Components() (component.Factories, error) {
 	}
 
 	factories := component.Factories{
-		Receivers: receivers,
-		Exporters: exporters,
+		Receivers:  receivers,
+		Exporters:  exporters,
 		Processors: processors,
 	}
 


### PR DESCRIPTION
Added the Prometheus Remote Write (PRW) exporter into the Collector Lambda Layer. 
Tested by running `make publish-layer` in the `/collector` folder, which successfully publishes the layer to Lambda. 