### PR TITLE
Add metric to AWS SDK sample app

### DIFF
--- a/java/sample-apps/aws-sdk/build.gradle.kts
+++ b/java/sample-apps/aws-sdk/build.gradle.kts
@@ -4,6 +4,8 @@ plugins {
 }
 
 dependencies {
+    implementation("io.opentelemetry:opentelemetry-api")
+    implementation("io.opentelemetry:opentelemetry-api-metrics")
     implementation("com.amazonaws:aws-lambda-java-core")
     implementation("com.amazonaws:aws-lambda-java-events")
     implementation("org.apache.logging.log4j:log4j-core")

--- a/java/sample-apps/aws-sdk/src/main/java/io/opentelemetry/lambda/sampleapps/awssdk/AwsSdkRequestHandler.java
+++ b/java/sample-apps/aws-sdk/src/main/java/io/opentelemetry/lambda/sampleapps/awssdk/AwsSdkRequestHandler.java
@@ -40,8 +40,6 @@ public class AwsSdkRequestHandler
     // Generate a sample counter metric using the OpenTelemetry Java Metrics API
     queueSizeCounter.add(2, Labels.of("apiName", "apiName", "statuscode", "200"));
 
-    System.out.println("emit metric with queue size change " + 2 + "," + "apiName" + "," + "200");
-
     return response;
   }
 }

--- a/java/sample-apps/aws-sdk/src/main/java/io/opentelemetry/lambda/sampleapps/awssdk/AwsSdkRequestHandler.java
+++ b/java/sample-apps/aws-sdk/src/main/java/io/opentelemetry/lambda/sampleapps/awssdk/AwsSdkRequestHandler.java
@@ -20,7 +20,7 @@ public class AwsSdkRequestHandler
   private static Meter sampleMeter = GlobalMeterProvider.getMeter("aws-otel", "1.0");
   LongUpDownCounter queueSizeCounter =
       sampleMeter
-          .longUpDownCounterBuilder("queueSizeChangeMetricName")
+          .longUpDownCounterBuilder("queueSizeChange")
           .setDescription("Queue Size change")
           .setUnit("one")
           .build();

--- a/java/sample-apps/aws-sdk/src/main/java/io/opentelemetry/lambda/sampleapps/awssdk/AwsSdkRequestHandler.java
+++ b/java/sample-apps/aws-sdk/src/main/java/io/opentelemetry/lambda/sampleapps/awssdk/AwsSdkRequestHandler.java
@@ -17,6 +17,13 @@ public class AwsSdkRequestHandler
     implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
   private static final Logger logger = LogManager.getLogger(AwsSdkRequestHandler.class);
+  private static Meter sampleMeter = GlobalMeterProvider.getMeter("aws-otel", "1.0");
+  LongUpDownCounter queueSizeCounter =
+      sampleMeter
+          .longUpDownCounterBuilder("queueSizeChangeMetricName")
+          .setDescription("Queue Size change")
+          .setUnit("one")
+          .build();
 
   @Override
   public APIGatewayProxyResponseEvent handleRequest(
@@ -31,14 +38,6 @@ public class AwsSdkRequestHandler
     }
 
     // Generate a sample counter metric using the OpenTelemetry Java Metrics API
-    Meter sampleMeter = GlobalMeterProvider.getMeter("aws-otel", "1.0");
-    LongUpDownCounter queueSizeCounter =
-        sampleMeter
-            .longUpDownCounterBuilder("queueSizeChangeMetricName")
-            .setDescription("Queue Size change")
-            .setUnit("one")
-            .build();
-
     queueSizeCounter.add(2, Labels.of("apiName", "apiName", "statuscode", "200"));
 
     System.out.println("emit metric with queue size change " + 2 + "," + "apiName" + "," + "200");

--- a/java/sample-apps/aws-sdk/src/main/java/io/opentelemetry/lambda/sampleapps/awssdk/AwsSdkRequestHandler.java
+++ b/java/sample-apps/aws-sdk/src/main/java/io/opentelemetry/lambda/sampleapps/awssdk/AwsSdkRequestHandler.java
@@ -4,6 +4,10 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import io.opentelemetry.api.metrics.GlobalMeterProvider;
+import io.opentelemetry.api.metrics.LongUpDownCounter;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.common.Labels;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -25,6 +29,20 @@ public class AwsSdkRequestHandler
       response.setBody(
           "Hello lambda - found " + listBucketsResponse.buckets().size() + " buckets.");
     }
+
+    // Generate a sample counter metric using the OpenTelemetry Java Metrics API
+    Meter sampleMeter = GlobalMeterProvider.getMeter("aws-otel", "1.0");
+    LongUpDownCounter queueSizeCounter =
+        sampleMeter
+            .longUpDownCounterBuilder("queueSizeChangeMetricName")
+            .setDescription("Queue Size change")
+            .setUnit("one")
+            .build();
+
+    queueSizeCounter.add(2, Labels.of("apiName", "apiName", "statuscode", "200"));
+
+    System.out.println("emit metric with queue size change " + 2 + "," + "apiName" + "," + "200");
+
     return response;
   }
 }

--- a/java/sample-apps/aws-sdk/src/main/java/io/opentelemetry/lambda/sampleapps/awssdk/AwsSdkRequestHandler.java
+++ b/java/sample-apps/aws-sdk/src/main/java/io/opentelemetry/lambda/sampleapps/awssdk/AwsSdkRequestHandler.java
@@ -17,8 +17,8 @@ public class AwsSdkRequestHandler
     implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
   private static final Logger logger = LogManager.getLogger(AwsSdkRequestHandler.class);
-  private static Meter sampleMeter = GlobalMeterProvider.getMeter("aws-otel", "1.0");
-  LongUpDownCounter queueSizeCounter =
+  private static final Meter sampleMeter = GlobalMeterProvider.getMeter("aws-otel", "1.0");
+  private static final LongUpDownCounter queueSizeCounter =
       sampleMeter
           .longUpDownCounterBuilder("queueSizeChange")
           .setDescription("Queue Size change")


### PR DESCRIPTION
This sample app will be used for the integration tests downstream to verify the Prometheus Metric pipeline to AMP is working. 

Verified using Terraform that changes made here are able to successfully send metrics to AMP and does not break the existing sample app functionality. 