### PR TITLE
Updates to Java AWS SDK sample app Terraform Configuration to Support a Custom Collector Configuration File

### DIFF
--- a/java/integration-tests/aws-sdk/agent/main.tf
+++ b/java/integration-tests/aws-sdk/agent/main.tf
@@ -16,12 +16,12 @@ resource "aws_lambda_layer_version" "collector_layer" {
 }
 
 module "hello-lambda-function" {
-  source              = "../../../sample-apps/aws-sdk/deploy/agent"
-  name                = var.function_name
-  collector_layer_arn = var.enable_collector_layer ? aws_lambda_layer_version.collector_layer[0].arn : null
-  sdk_layer_arn       = aws_lambda_layer_version.sdk_layer.arn
-  collector_config_layer_arn = var.collector_config_layer_arn 
-  tracing_mode        = var.tracing_mode
+  source                     = "../../../sample-apps/aws-sdk/deploy/agent"
+  name                       = var.function_name
+  collector_layer_arn        = var.enable_collector_layer ? aws_lambda_layer_version.collector_layer[0].arn : null
+  sdk_layer_arn              = aws_lambda_layer_version.sdk_layer.arn
+  collector_config_layer_arn = var.collector_config_layer_arn
+  tracing_mode               = var.tracing_mode
 }
 
 resource "aws_iam_role_policy_attachment" "hello-lambda-cloudwatch-insights" {

--- a/java/integration-tests/aws-sdk/agent/main.tf
+++ b/java/integration-tests/aws-sdk/agent/main.tf
@@ -20,6 +20,7 @@ module "hello-lambda-function" {
   name                = var.function_name
   collector_layer_arn = var.enable_collector_layer ? aws_lambda_layer_version.collector_layer[0].arn : null
   sdk_layer_arn       = aws_lambda_layer_version.sdk_layer.arn
+  collector_config_layer_arn = var.collector_config_layer_arn 
   tracing_mode        = var.tracing_mode
 }
 

--- a/java/integration-tests/aws-sdk/agent/variables.tf
+++ b/java/integration-tests/aws-sdk/agent/variables.tf
@@ -10,6 +10,11 @@ variable "sdk_layer_name" {
   default     = "opentelemetry-java-agent"
 }
 
+variable "collector_config_layer_arn" {
+  type        = string
+  description = "Name of published SDK layer"
+}
+
 variable "function_name" {
   type        = string
   description = "Name of sample app function / API gateway"

--- a/java/sample-apps/aws-sdk/README.md
+++ b/java/sample-apps/aws-sdk/README.md
@@ -24,6 +24,8 @@ terraform init
 terraform apply
 ```
 
+For the agent version, to optionally enable a pipeline to send Prometheus metrics to a Prometheus backend, provide the ARN of a lambda layer with a custom collector configuration in a file named `config.yaml` when prompted after running the `terraform apply` command. 
+
 After deployment, a URL which can be used to invoke the function via API Gateway will be displayed. The agent version
 tends to take 10-20s for the first request, while the wrapper version tends to take 5-10s. Confirm
 that spans are logged in the CloudWatch logs for the function on the AWS Console either for the

--- a/java/sample-apps/aws-sdk/deploy/agent/main.tf
+++ b/java/sample-apps/aws-sdk/deploy/agent/main.tf
@@ -18,13 +18,13 @@ module "hello-lambda-function" {
     var.collector_config_layer_arn,
   ])
 
-  environment_variables =  (var.collector_config_layer_arn == null? 
-  {
-    AWS_LAMBDA_EXEC_WRAPPER = "/opt/otel-handler",
-  } : 
-  {
-    AWS_LAMBDA_EXEC_WRAPPER = "/opt/otel-handler",
-    OPENTELEMETRY_COLLECTOR_CONFIG_FILE	= "/opt/config.yaml"
+  environment_variables = (var.collector_config_layer_arn == null ?
+    {
+      AWS_LAMBDA_EXEC_WRAPPER = "/opt/otel-handler",
+    } :
+    {
+      AWS_LAMBDA_EXEC_WRAPPER             = "/opt/otel-handler",
+      OPENTELEMETRY_COLLECTOR_CONFIG_FILE = "/opt/config.yaml"
   })
 
   tracing_mode = var.tracing_mode

--- a/java/sample-apps/aws-sdk/deploy/agent/main.tf
+++ b/java/sample-apps/aws-sdk/deploy/agent/main.tf
@@ -20,7 +20,7 @@ module "hello-lambda-function" {
 
   environment_variables = {
     AWS_LAMBDA_EXEC_WRAPPER = "/opt/otel-handler",
-    OPENTELEMETRY_COLLECTOR_CONFIG_FILE	= "/opt/collector.yaml",
+    OPENTELEMETRY_COLLECTOR_CONFIG_FILE	= "/opt/config.yaml",
   }
 
   tracing_mode = var.tracing_mode

--- a/java/sample-apps/aws-sdk/deploy/agent/main.tf
+++ b/java/sample-apps/aws-sdk/deploy/agent/main.tf
@@ -18,10 +18,14 @@ module "hello-lambda-function" {
     var.collector_config_layer_arn,
   ])
 
-  environment_variables = {
+  environment_variables =  (var.collector_config_layer_arn == null? 
+  {
     AWS_LAMBDA_EXEC_WRAPPER = "/opt/otel-handler",
-    OPENTELEMETRY_COLLECTOR_CONFIG_FILE	= "/opt/config.yaml",
-  }
+  } : 
+  {
+    AWS_LAMBDA_EXEC_WRAPPER = "/opt/otel-handler",
+    OPENTELEMETRY_COLLECTOR_CONFIG_FILE	= "/opt/config.yaml"
+  })
 
   tracing_mode = var.tracing_mode
 

--- a/java/sample-apps/aws-sdk/deploy/agent/main.tf
+++ b/java/sample-apps/aws-sdk/deploy/agent/main.tf
@@ -14,11 +14,13 @@ module "hello-lambda-function" {
 
   layers = compact([
     var.collector_layer_arn,
-    var.sdk_layer_arn
+    var.sdk_layer_arn,
+    var.collector_config_layer_arn,
   ])
 
   environment_variables = {
-    AWS_LAMBDA_EXEC_WRAPPER = "/opt/otel-handler"
+    AWS_LAMBDA_EXEC_WRAPPER = "/opt/otel-handler",
+    OPENTELEMETRY_COLLECTOR_CONFIG_FILE	= "/opt/collector.yaml",
   }
 
   tracing_mode = var.tracing_mode

--- a/java/sample-apps/aws-sdk/deploy/agent/variables.tf
+++ b/java/sample-apps/aws-sdk/deploy/agent/variables.tf
@@ -10,12 +10,10 @@ variable "collector_layer_arn" {
   // TODO(anuraaga): Add default when a public layer is published.
 }
 
-
 variable "collector_config_layer_arn" {
   type        = string
   description = "ARN for the Lambda layer containing the OpenTelemetry collector configuration file"
 }
-
 
 variable "sdk_layer_arn" {
   type        = string

--- a/java/sample-apps/aws-sdk/deploy/agent/variables.tf
+++ b/java/sample-apps/aws-sdk/deploy/agent/variables.tf
@@ -10,6 +10,15 @@ variable "collector_layer_arn" {
   // TODO(anuraaga): Add default when a public layer is published.
 }
 
+
+variable "collector_config_layer_arn" {
+  type        = string
+  description = "ARN for the Lambda layer containing the OpenTelemetry collector configuration file"
+  // TODO(anuraaga): Add default when a public layer is published.
+  default = "arn:aws:lambda:us-east-1:614732350472:layer:CustomCollectorConfig:1"
+}
+
+
 variable "sdk_layer_arn" {
   type        = string
   description = "ARN for the Lambda layer containing the OpenTelemetry Java Agent"

--- a/java/sample-apps/aws-sdk/deploy/agent/variables.tf
+++ b/java/sample-apps/aws-sdk/deploy/agent/variables.tf
@@ -14,8 +14,6 @@ variable "collector_layer_arn" {
 variable "collector_config_layer_arn" {
   type        = string
   description = "ARN for the Lambda layer containing the OpenTelemetry collector configuration file"
-  // TODO(anuraaga): Add default when a public layer is published.
-  default = "arn:aws:lambda:us-east-1:614732350472:layer:CustomCollectorConfig:1"
 }
 
 


### PR DESCRIPTION
This PR adds the ability to add an optional custom collector configuration file to the [Java AWS SDK Agent sample app](https://github.com/open-telemetry/opentelemetry-lambda/tree/main/java/sample-apps/aws-sdk/deploy/agent). A specific benefit of this is to allow users to specify the Prometheus backend endpoint to send their metrics to using this sample application. 